### PR TITLE
[mic-043] function return 경고 메세지 ignore 처리

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,13 +48,8 @@
         "@typescript-eslint/no-unused-vars": ["error"],
 
         // I suggest this setting for requiring return types on functions only where useful
-        "@typescript-eslint/explicit-function-return-type": [
-          "warn",
-          {
-            "allowExpressions": true,
-            "allowConciseArrowFunctionExpressionsStartingWithVoid": true,
-          },
-        ],
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/explicit-module-boundary-types": "off", 
 
         // Includes .prettierrc.js rules
         "prettier/prettier": ["error", {}, {


### PR DESCRIPTION
- function return 경고 메세지 ignore 처리하였습니다
타입 스크립트가 함수 반환문을 보고 알아서 추론을 하기 때문에 리턴 타입 생략 가능하도록 eslint 수정하였습니다